### PR TITLE
Fixed up 422 error logging in redmine time entry service.

### DIFF
--- a/src/synced_services/redmine/redmine_synced_service.ts
+++ b/src/synced_services/redmine/redmine_synced_service.ts
@@ -496,7 +496,7 @@ export class RedmineSyncedService implements SyncedService {
     );
 
     if (!response || !response.ok) {
-
+      //TODO potentially add some minor logging here
       return null;
     }
 

--- a/src/synced_services/redmine/redmine_synced_service.ts
+++ b/src/synced_services/redmine/redmine_synced_service.ts
@@ -87,10 +87,12 @@ export class RedmineSyncedService implements SyncedService {
           needToWait = true;
         } else if (res.status === 422) {
             const error = this._errorService.createRedmineError(res.body.errors);
-            let context = null;
+          const context =  [
+            this._sentryService.createExtraContext("Status_code", {'status_code': res.status})
+          ]
             if (body) {
               // don't know how to create context from body otherwise. This is a band-aid solution.
-              context = this._sentryService.createExtraContext("Time entry", JSON.parse(JSON.stringify(body)));
+              context.push(this._sentryService.createExtraContext("Time entry", JSON.parse(JSON.stringify(body))));
               error.data = body;
             }
             this.errors.push(error);


### PR DESCRIPTION
Moved logging of 422 so that time entries that cant be synced will get logged. Instead of only unprocessable entity with no info.